### PR TITLE
fixed RES having same color text and background on highlighted usernames

### DIFF
--- a/src/naut_src.css
+++ b/src/naut_src.css
@@ -2053,6 +2053,7 @@
 											padding: 1px 4px;
 											border-radius: 1px;
 											background-color: #4F8EF7 !important;
+											color: #fff !important;
 											box-shadow: 0px 0px 0px rgba(0, 0, 0, 0);
 											transition: all 0.15s ease;
 										}
@@ -2593,7 +2594,7 @@
 
 				/* Bunch of RES (Reddit Enhancement Suite) Fixes */
 				.res .link .tagline a.voteWeight {background-color: transparent !important;}
-				.res .thing .tagline .author.moderator {background-color: #65B354 !important;padding: 1px 4px;border-radius: 1px;}
+				.res .thing .tagline .author.moderator {background-color: #65B354 !important;color: #fff !important;padding: 1px 4px;border-radius: 1px;}
 
 				.res .srSep {color: rgba(255,255,255,0.45);}
 				.res #RESShortcutsViewport {margin-right:381px;}


### PR DESCRIPTION
This happened when RES highlights Mods and OP usernames:

![example1](http://i.imgur.com/IRiu9wd.png)


![example2](http://i.imgur.com/DNtZhGg.png)
